### PR TITLE
Account for new "codename" term in error

### DIFF
--- a/src/pgsql_migration.erl
+++ b/src/pgsql_migration.erl
@@ -10,6 +10,10 @@ migrate(Conn, Version, Dir) ->
     BinVersion = list_to_binary(Version),
     case ?DRIVER:squery(Conn, "SELECT id FROM migrations ORDER BY id DESC") of
         {error, {error, error, <<"42P01">>, _, _}} ->
+            %% support legacy error message arity
+            init_migrations(Conn),
+            migrate(Conn, Version, Dir);
+        {error, {error, error, <<"42P01">>, _, _, _}} ->
             %% init migrations and restart
             init_migrations(Conn),
             migrate(Conn, Version, Dir);


### PR DESCRIPTION
epgsql 3.2 introduced [a codename atom](https://github.com/epgsql/epgsql/commit/8f766ca37ef2f810a2c27bedcbed01b551893e5a) in the error tuple, thereby
increasing the number of fields, breaking the case statement. Since we
don't particularly care for the specific information returned in this
new field, we can just increase the number of ignored terms to make the
arity match and continue on.

I'm not sure how this will affect backwards-compatibility with previous epgsql versions...
